### PR TITLE
Use GitHub Models to scan posts for PII

### DIFF
--- a/.github/prompts/pii-scan.prompt.yml
+++ b/.github/prompts/pii-scan.prompt.yml
@@ -1,0 +1,74 @@
+messages:
+  - role: system
+    content: |
+      You are a security reviewer that specializes in identifying newly introduced
+      personally identifiable information (PII) in Markdown blog posts. Treat any
+      email addresses, phone numbers, social security numbers, credit card data,
+      account identifiers, GPS coordinates, or other data that can directly or
+      indirectly identify a person as PII. Flag secrets or access tokens as PII as
+      well. Only consider additions in the diff; removals are not concerns.
+  - role: user
+    content: |
+      A pull request (number {{pr_number}}) is updating one or more files inside
+      the `_posts/` directory. Review the provided unified diff and determine if
+      any change introduces PII. If nothing in the diff adds PII, respond with an
+      empty findings list and set `pii_detected` to false.
+
+      When PII is present, provide focused findings that help a reviewer remediate
+      the issue. Use the file path and approximate line number from the diff as the
+      `location` field, include a short snippet that captures the risky content,
+      explain why it is sensitive, and assign a confidence of `low`, `medium`, or
+      `high`.
+
+      Diff to review:
+      {{diff}}
+model: openai/gpt-4o-mini
+responseFormat: json_schema
+jsonSchema: |
+  {
+    "name": "pii_audit",
+    "strict": true,
+    "schema": {
+      "type": "object",
+      "properties": {
+        "pii_detected": {
+          "type": "boolean",
+          "description": "Whether any PII appears in the diff"
+        },
+        "findings": {
+          "type": "array",
+          "description": "Summaries of each potential PII concern",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Short label for the type of PII (e.g., email, token, SSN)"
+              },
+              "location": {
+                "type": "string",
+                "description": "File path and line range where the PII occurs"
+              },
+              "snippet": {
+                "type": "string",
+                "description": "Minimal excerpt of the sensitive content"
+              },
+              "explanation": {
+                "type": "string",
+                "description": "Brief rationale describing the risk"
+              },
+              "confidence": {
+                "type": "string",
+                "enum": ["low", "medium", "high"],
+                "description": "Confidence in the assessment"
+              }
+            },
+            "required": ["type", "location", "snippet", "explanation", "confidence"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["pii_detected", "findings"],
+      "additionalProperties": false
+    }
+  }

--- a/.github/workflows/pii-check.yml
+++ b/.github/workflows/pii-check.yml
@@ -1,0 +1,72 @@
+name: PII Leak Check
+
+on:
+  pull_request:
+    paths:
+      - '_posts/**'
+
+jobs:
+  github-models-pii-scan:
+    name: Scan blog posts with GitHub Models
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      models: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect post changes
+        id: diff
+        run: |
+          set -euo pipefail
+
+          git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
+
+          git diff --unified=0 "origin/${{ github.event.pull_request.base.ref }}"...HEAD -- _posts > post_changes.diff || true
+
+          if [ ! -s post_changes.diff ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "diff_path=post_changes.diff" >> "$GITHUB_OUTPUT"
+
+      - name: Analyze diff for PII with GitHub Models
+        if: steps.diff.outputs.has_changes == 'true'
+        id: pii_scan
+        uses: actions/ai-inference@v1
+        with:
+          prompt-file: .github/prompts/pii-scan.prompt.yml
+          input: |
+            pr_number: ${{ github.event.pull_request.number }}
+          file_input: |
+            diff: ${{ steps.diff.outputs.diff_path }}
+
+      - name: Evaluate scan results
+        if: steps.diff.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+
+          response='${{ steps.pii_scan.outputs.response }}'
+
+          if [ -z "$response" ]; then
+            echo "Model response was empty" >&2
+            exit 1
+          fi
+
+          echo "Model response:" >&2
+          echo "$response" | jq '.' >&2
+
+          pii_detected=$(jq -r '.pii_detected' <<<"$response")
+
+          if [ "$pii_detected" = "true" ]; then
+            jq -r '.findings[] | "::error file=" + (.location // "_posts") + "::[" + (.confidence | ascii_upcase) + "] " + .type + " - " + .explanation' <<<"$response"
+            exit 1
+          fi
+
+          echo "::notice::No PII detected in updated posts"


### PR DESCRIPTION
## Summary
- replace the gitleaks-based PII workflow with a GitHub Models powered scan for blog post changes
- add a structured prompt to drive consistent JSON findings and fail the job when PII is detected

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e62f873f94832ba66d2f0b92a5fe42